### PR TITLE
Navigate Using Root Path when Access Denied

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
     return if user_signed_in? && current_user.public_send("#{type}?")
 
     session[:return_to] = request.url unless action_name == 'sign_in'
-    deny_access new_user_session_path
+    deny_access root_path
   end
 
   def deny_access(path)


### PR DESCRIPTION
Users are now redirected using root path instead of the login page path when access to a page is denied. This resolves the issue where notice describes the user as being already logged-in and access error is not shown.