### PR TITLE
Allow students and staffs to view their loan history

### DIFF
--- a/app/views/books/show.haml
+++ b/app/views/books/show.haml
@@ -35,38 +35,39 @@
 %br
 
 - if current_user.library_manager?
-  %h2 Loan History
-  %table
-    %thead
-      %tr 
-        %th User ID
-        %th Borrow date
-        %th Return date
-        %th Late return
-        %th Fine
-    %tbody
-    - @book.loans.each do |loan| 
-      %tr
-        %td= loan.user.id
-        %td= loan.borrowed_at.strftime("%d/%m/%Y")
-        - if loan.returned_at == nil
-          %td Book still borrowed, due #{loan.to_be_returned_at.strftime("%d/%m/%Y")}
-          %td N/A
-          %td N/A
-        - else
-          %td= loan.returned_at.strftime("%d/%m/%Y")
-          - if loan.returned_at <= loan.to_be_returned_at
-            %td No
+  - if @book.loans.present?
+    %h2 Loan History
+    %table
+      %thead
+        %tr 
+          %th User ID
+          %th Borrow date
+          %th Return date
+          %th Late return
+          %th Fine
+      %tbody
+      - @book.loans.each do |loan| 
+        %tr
+          %td= loan.user.id
+          %td= loan.borrowed_at.strftime("%d/%m/%Y")
+          - if loan.returned_at == nil
+            %td Book still borrowed, due #{loan.to_be_returned_at.strftime("%d/%m/%Y")}
             %td N/A
-          - else 
-            %td Yes
-            - if loan.fine.present?
-              - if loan.fine.charged_at == nil 
-                %td Amount: #{loan.fine.amount} - Unpaid
-              - else 
-                %td Amount: #{loan.fine.amount} - Paid
+            %td N/A
+          - else
+            %td= loan.returned_at.strftime("%d/%m/%Y")
+            - if loan.returned_at <= loan.to_be_returned_at
+              %td No
+              %td N/A
             - else 
-              %td No fine
+              %td Yes
+              - if loan.fine.present?
+                - if loan.fine.charged_at == nil 
+                  %td Amount: #{loan.fine.amount} - Unpaid
+                - else 
+                  %td Amount: #{loan.fine.amount} - Paid
+              - else 
+                %td No fine
   %br
   = link_to 'Edit', edit_book_path(@book)
 = link_to 'Back', books_path

--- a/app/views/layouts/staff.haml
+++ b/app/views/layouts/staff.haml
@@ -15,3 +15,4 @@
   
     = link_to 'Log out', destroy_user_session_path, method: :delete
     = link_to 'Change info', edit_user_registration_path
+    = link_to 'Listing books', books_path

--- a/app/views/layouts/student.haml
+++ b/app/views/layouts/student.haml
@@ -15,3 +15,4 @@
     
     = link_to 'Log out', destroy_user_session_path, method: :delete
     = link_to 'Change info', edit_user_registration_path
+    = link_to 'Listing books', books_path

--- a/app/views/staff/dashboard/show.haml
+++ b/app/views/staff/dashboard/show.haml
@@ -1,4 +1,4 @@
-%h3 Hi there
+%h3 Dashboard
 
 %table
   %thead
@@ -27,3 +27,31 @@
         %td= link_to 'Destroy', book, method: :delete, data: { confirm: 'Are you sure?' }
 
 %br
+
+- if current_user.loans.present?
+  %h4 Loan History
+  %table
+    %thead
+      %tr 
+        %th Title
+        %th Reference
+        %th Borrow date
+        %th Return date
+        %th Fine
+    %tbody
+    - current_user.loans.reverse_each do |loan| 
+      %tr
+        %td= loan.book.title
+        %td= loan.book.reference_number
+        %td= loan.borrowed_at.strftime("%d/%m/%Y")
+        - if loan.returned_at == nil
+          %td Book still borrowed, due #{loan.to_be_returned_at.strftime("%d/%m/%Y")}
+        - else
+          %td= loan.returned_at.strftime("%d/%m/%Y")
+        - if loan.fine.present?
+          - if loan.fine.charged_at == nil 
+            %td Amount: #{loan.fine.amount} - Unpaid
+          - else 
+            %td Amount: #{loan.fine.amount} - Paid
+        - else 
+          %td No fine

--- a/app/views/students/dashboard/show.haml
+++ b/app/views/students/dashboard/show.haml
@@ -23,3 +23,31 @@
         %td= link_to 'Show', book
 
 %br
+
+- if current_user.loans.present?
+  %h4 Loan History
+  %table
+    %thead
+      %tr 
+        %th Title
+        %th Reference
+        %th Borrow date
+        %th Return date
+        %th Fine
+    %tbody
+    - current_user.loans.reverse_each do |loan| 
+      %tr
+        %td= loan.book.title
+        %td= loan.book.reference_number
+        %td= loan.borrowed_at.strftime("%d/%m/%Y")
+        - if loan.returned_at == nil
+          %td Book still borrowed, due #{loan.to_be_returned_at.strftime("%d/%m/%Y")}
+        - else
+          %td= loan.returned_at.strftime("%d/%m/%Y")
+        - if loan.fine.present?
+          - if loan.fine.charged_at == nil 
+            %td Amount: #{loan.fine.amount} - Unpaid
+          - else 
+            %td Amount: #{loan.fine.amount} - Paid
+        - else 
+          %td No fine


### PR DESCRIPTION
#### What does this PR do?
Allow students and staffs to view their loan history (including borrow date, return date and potential fine)

#### How can this PR be tested?
Log in as a student and staff, borrow books (if not done yet), then the loan history will be below the Dashboard. 

#### Does this PR relate to a User Story? If so, link it here
US13: https://trello.com/c/7h5vCIPH
US19: https://trello.com/c/LIvnn8NC

#### Screenshots

#### Other relevant information about these changes