### PR TITLE
US009: Update Book Details

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -46,8 +46,8 @@ class BooksController < ApplicationController
   # PATCH/PUT /books/1
   # PATCH/PUT /books/1.json
   def update
-    @book.cover_image.attach(params[:cover_image]) if !(params[:cover_image].nil?)
-    @book.content.attach(params[:content]) if !(params[:content].nil?)
+    @book.cover_image.attach(params[:cover_image]) unless params[:cover_image].nil?
+    @book.content.attach(params[:content]) unless params[:content].nil?
 
     respond_to do |format|
       if @book.update(book_params)

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -46,8 +46,8 @@ class BooksController < ApplicationController
   # PATCH/PUT /books/1
   # PATCH/PUT /books/1.json
   def update
-    @book.cover_image.attach(params[:cover_image])
-    @book.content.attach(params[:content])
+    @book.cover_image.attach(params[:cover_image]) if !(params[:cover_image].nil?)
+    @book.content.attach(params[:content]) if !(params[:content].nil?)
 
     respond_to do |format|
       if @book.update(book_params)


### PR DESCRIPTION
#### What does this PR do?
Fix issue where book cover image and PDF content is removed when not resupplied while updating details.

#### How can this PR be tested?
Update book details whose cover image or PDF content exists and do not supply one or both of those items.

#### Screenshots
None.

#### Other relevant information about these changes
None.